### PR TITLE
Add simple loginRegister from.

### DIFF
--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -117,6 +117,8 @@ def login_and_registration_form(request, initial_mode="login"):
         'allow_iframing': True,
         'disable_courseware_js': True,
     }
+    if request.GET.get('type', None) == '0':
+        context.update({'disable_footer': True, 'disable_header': True, 'disable_window_wrap': True})
 
     return render_to_response('student_account/login_and_register.html', context)
 

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -60,9 +60,9 @@
 
                 if (options.login_redirect_url) {
                     // Ensure that the next URL is internal for security reasons
-                    if ( ! window.isExternal( options.login_redirect_url ) ) {
+                    // if ( ! window.isExternal( options.login_redirect_url ) ) {
                         this.nextUrl = options.login_redirect_url;
-                    }
+                    // }
                 }
 
                 this.formDescriptions = {


### PR DESCRIPTION
1. Header, Footer are disabled.
2. Enabled possibility to redirect to external URLs.

Url Example: `http://localhost:8000/login?next=http%3A%2F%2Fexample.com&type=0`

Example:
![screenshot 2015-12-26 13 15 17](https://cloud.githubusercontent.com/assets/1247491/12006149/d47cc2d6-abd2-11e5-8d65-2bad94a5b29b.png)
