### PR TITLE
WEB-228. Added save remaped ids to dump in json format

### DIFF
--- a/common/djangoapps/student/management/commands/anonymousid_remap.py
+++ b/common/djangoapps/student/management/commands/anonymousid_remap.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
         from django.conf import settings
         secret_key = settings.SECRET_KEY
         qs = AnonymousUserId.objects.all()
-        remaped = []
+        remapped = []
         for student in qs:
             hasher = hashlib.md5()
             hasher.update(secret_key)
@@ -39,7 +39,7 @@ class Command(BaseCommand):
                 old_id = student.anonymous_user_id
                 student.anonymous_user_id = digest
                 student.save()
-                remaped.append({
+                remapped.append({
                     "old_id": old_id,
                     "new_id": digest,
                     "email": student.user.email,
@@ -51,7 +51,7 @@ class Command(BaseCommand):
             filename_postfix.strftime('%Y-%m-%d_%H:%M:%S_%Z')
         )
         with open(filename, 'w') as outfile:
-            json.dump({"dump": remaped}, outfile)
+            json.dump({"dump": remapped}, outfile)
         self.stdout.write(
-            "{} ids were changed of total {}".format(len(remaped), qs.count())
+            "{} ids were changed of total {}".format(len(remapped), qs.count())
         )

--- a/common/djangoapps/student/management/commands/anonymousid_remap.py
+++ b/common/djangoapps/student/management/commands/anonymousid_remap.py
@@ -5,6 +5,8 @@ Must be called when django secret key was changed
 """
 
 import hashlib
+import json
+import datetime
 from django.core.management.base import BaseCommand, CommandError
 from student.models import AnonymousUserId
 
@@ -17,7 +19,7 @@ class Command(BaseCommand):
         from django.conf import settings
         secret_key = settings.SECRET_KEY
         qs = AnonymousUserId.objects.all()
-        remaped_count = 0
+        remaped = []
         for student in qs:
             hasher = hashlib.md5()
             hasher.update(secret_key)
@@ -33,9 +35,19 @@ class Command(BaseCommand):
                         student.user.id
                     )
                 )
+                old_id = student.anonymous_user_id
                 student.anonymous_user_id = digest
                 student.save()
-                remaped_count += 1
+                remaped.append({
+                    "old_id": old_id,
+                    "new_id": digest,
+                    "email": student.user.email,
+                    "course_id": student.course_id.to_deprecated_string()
+                        .encode('utf-8') if student.course_id else ""
+                })
+        filename = "anonymous_ids-{}.json".format(datetime.datetime.now())
+        with open(filename, 'w') as outfile:
+            json.dump({"dump": remaped}, outfile)
         self.stdout.write(
-            "{} ids were changed of total {}".format(remaped_count, qs.count())
+            "{} ids were changed of total {}".format(len(remaped), qs.count())
         )

--- a/common/djangoapps/student/management/commands/anonymousid_remap.py
+++ b/common/djangoapps/student/management/commands/anonymousid_remap.py
@@ -7,6 +7,7 @@ Must be called when django secret key was changed
 import hashlib
 import json
 import datetime
+from dateutil.tz import tzlocal
 from django.core.management.base import BaseCommand, CommandError
 from student.models import AnonymousUserId
 
@@ -45,7 +46,10 @@ class Command(BaseCommand):
                     "course_id": student.course_id.to_deprecated_string()
                         .encode('utf-8') if student.course_id else ""
                 })
-        filename = "anonymous_ids-{}.json".format(datetime.datetime.now())
+        filename_postfix = datetime.datetime.now(tzlocal())
+        filename = "anonymous_ids_{}.json".format(
+            filename_postfix.strftime('%Y-%m-%d_%H:%M:%S_%Z')
+        )
         with open(filename, 'w') as outfile:
             json.dump({"dump": remaped}, outfile)
         self.stdout.write(


### PR DESCRIPTION
### Story

https://liv-it.atlassian.net/browse/WEB-228
https://liv-it.atlassian.net/browse/WEB-296
### Related PR

https://github.com/Livit/Livit.Learn.LTI/pull/54
### Description

Added generating json dump when all anonymous ids are remapped.
### Steps to test (devstack)
- change secret key in `lms/envs/devstack.py`
- run `manage.py anonymousid_remap`
- check there is json file like **anonymous_ids_*.json** in the current directory

@auraz @polesye @avkoval 
