### PR TITLE
Move Teacher Dashboard into Master Course.

### DIFF
--- a/lms/djangoapps/teacher_dashboard/tests/test_utils.py
+++ b/lms/djangoapps/teacher_dashboard/tests/test_utils.py
@@ -1,0 +1,154 @@
+"""
+Tests for utils.
+./manage.py lms test --verbosity=1 lms/djangoapps/teacher_dashboard   --traceback --settings=labster_test
+"""
+
+from django.test.utils import override_settings
+
+from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, TEST_DATA_SPLIT_MODULESTORE
+
+from ccx.tests.factories import CcxFactory
+from ccx_keys.locator import CCXLocator
+from student.roles import CourseCcxCoachRole
+from student.tests.factories import UserFactory
+from lms.djangoapps.teacher_dashboard.utils import has_teacher_access
+
+
+class HasTeacherAccessTests(ModuleStoreTestCase):
+    """
+    All tests for the views.py file
+    """
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
+
+    def setUp(self):
+        """
+        Set up the test data used in the specific tests
+        """
+        super(HasTeacherAccessTests, self).setUp()
+
+        self.user = UserFactory.create()
+
+    def make_coach(self, course, coach):
+        """
+        Create coach user.
+        """
+        role = CourseCcxCoachRole(course.id)
+        role.add_users(coach)
+
+    def make_ccx(self, course, coach):
+        """
+        Create ccx.
+        """
+        ccx = CcxFactory(course_id=course.id, coach=coach)
+        return ccx
+
+    def make_course(self, enable_ccx=True):
+        return CourseFactory.create(enable_ccx=enable_ccx, display_name='Test Course')
+
+    def get_course(self, key):
+        """
+        Get a course for a given key
+        """
+        with self.store.bulk_operations(key):
+            course = self.store.get_course(key)
+        return course
+
+    @override_settings(
+        LABSTER_FEATURES={'ENABLE_TEACHER_DASHBOARD': True},
+        FEATURES={'CUSTOM_COURSES_EDX': True},
+    )
+    def test_user_unavailable(self):
+        """
+        Asserts that an anonymous user cannot access Teacher Dashboard.
+        """
+        course = self.make_course()
+        self.make_coach(course, self.user)
+        ccx = self.make_ccx(course, self.user)
+
+        self.assertFalse(has_teacher_access(None, course))
+
+    @override_settings(
+        LABSTER_FEATURES={'ENABLE_TEACHER_DASHBOARD': False},
+        FEATURES={'CUSTOM_COURSES_EDX': True},
+    )
+    def test_teacher_dashboard_is_disabled(self):
+        """
+        Asserts that users cannot access Teacher Dashboard if it is disabled.
+        """
+        course = self.make_course()
+        self.make_coach(course, self.user)
+        ccx = self.make_ccx(course, self.user)
+
+        self.assertFalse(has_teacher_access(self.user, course))
+
+    @override_settings(
+        LABSTER_FEATURES={'ENABLE_TEACHER_DASHBOARD': True},
+        FEATURES={'CUSTOM_COURSES_EDX': False},
+    )
+    def test_ccx_feature_is_disabled(self):
+        """
+        Asserts that users cannot access Teacher Dashboard if CCX feature is disabled.
+        """
+        course = self.make_course()
+        self.make_coach(course, self.user)
+        ccx = self.make_ccx(course, self.user)
+
+        self.assertFalse(has_teacher_access(self.user, course))
+
+    @override_settings(
+        LABSTER_FEATURES={'ENABLE_TEACHER_DASHBOARD': True},
+        FEATURES={'CUSTOM_COURSES_EDX': True},
+    )
+    def test_ccx_is_disabled_in_course(self):
+        """
+        Asserts that users cannot access Teacher Dashboard if CCX is disabled in the course.
+        """
+        course = self.make_course(enable_ccx=False)
+        self.make_coach(course, self.user)
+        ccx = self.make_ccx(course, self.user)
+
+        self.assertFalse(has_teacher_access(self.user, course))
+
+    @override_settings(
+        LABSTER_FEATURES={'ENABLE_TEACHER_DASHBOARD': True},
+        FEATURES={'CUSTOM_COURSES_EDX': True},
+    )
+    def test_students_cannot_access(self):
+        """
+        Asserts that students cannot access Teacher Dashboard.
+        """
+        course = self.make_course()
+        ccx = self.make_ccx(course, self.user)
+
+        self.assertFalse(has_teacher_access(self.user, course))
+
+    @override_settings(
+        LABSTER_FEATURES={'ENABLE_TEACHER_DASHBOARD': True},
+        FEATURES={'CUSTOM_COURSES_EDX': True},
+    )
+    def test_dashboard_invisible_in_ccx(self):
+        """
+        Asserts that Teacher Dashboard invisible in CCX.
+        """
+        course = self.make_course()
+        self.make_coach(course, self.user)
+        ccx = self.make_ccx(course, self.user)
+        ccx_key = CCXLocator.from_course_locator(course.id, ccx.id)
+        ccx_course = self.get_course(ccx_key)
+
+        self.assertFalse(has_teacher_access(self.user, ccx_course))
+
+    @override_settings(
+        LABSTER_FEATURES={'ENABLE_TEACHER_DASHBOARD': True},
+        FEATURES={'CUSTOM_COURSES_EDX': True},
+    )
+    def test_coach_can_access(self):
+        """
+        Asserts that coach can access Teacher Dashboard.
+        """
+        course = self.make_course()
+        self.make_coach(course, self.user)
+        ccx = self.make_ccx(course, self.user)
+
+        self.assertTrue(has_teacher_access(self.user, course))

--- a/lms/djangoapps/teacher_dashboard/tests/test_views.py
+++ b/lms/djangoapps/teacher_dashboard/tests/test_views.py
@@ -1,5 +1,5 @@
 """
-Python tests for the Teacher Dashboard views
+Python tests for Teacher Dashboard views
 ./manage.py lms test --verbosity=1 lms/djangoapps/teacher_dashboard   --traceback --settings=labster_test
 """
 
@@ -18,7 +18,7 @@ from ccx.tests.factories import CcxFactory
 from ccx_keys.locator import CCXLocator
 from ccx.overrides import override_field_for_ccx
 from student.roles import CourseCcxCoachRole
-from student.tests.factories import AdminFactory
+from student.tests.factories import UserFactory
 
 
 TEST_DATA = json.dumps([{'display_name': 'test'}])
@@ -45,11 +45,12 @@ class TeacherDashboardViewsTests(ModuleStoreTestCase):
             display_name='Test Course', lti_passports=self.lti_passports
         )
         # Create instructor account
-        self.coach = AdminFactory.create()
+        self.user = UserFactory.create()
         self.make_coach()
         self.ccx = self.make_ccx()
+        self.ccx_key = CCXLocator.from_course_locator(self.course.id, self.ccx.id)
         self.view_url = reverse('teacher_dashboard.views.teacher_dahsboard_handler', args=[unicode(self.course.id)])
-        self.client.login(username=self.coach.username, password="test")
+        self.client.login(username=self.user.username, password="test")
 
     def make_lti_passports(self, consumer_keys):
         """
@@ -65,18 +66,29 @@ class TeacherDashboardViewsTests(ModuleStoreTestCase):
         Create coach user.
         """
         role = CourseCcxCoachRole(self.course.id)
-        role.add_users(self.coach)
+        role.add_users(self.user)
 
     def make_ccx(self):
         """
         Create ccx.
         """
-        ccx = CcxFactory(course_id=self.course.id, coach=self.coach)
+        ccx = CcxFactory(course_id=self.course.id, coach=self.user)
         return ccx
+
+    def test_student_cannot_see_teacher_dashboard(self):
+        """
+        Asserts that an unauthenticated user cannot access Teacher Dashboard.
+        """
+        student = UserFactory.create()
+        student_user = Client()
+        self.client.login(username=student.username, password="test")
+        url = reverse('teacher_dashboard.views.dashboard_view', args=[self.course.id])
+        response = student_user.get(url)
+        self.assertEquals(response.status_code, 302)
 
     def test_unauthenticated_teacher_view(self):
         """
-        Asserts that an unauthenticated user cannot access a Teacher Dashboard.
+        Asserts that an unauthenticated user cannot access Teacher Dashboard.
         """
         anon_user = Client()
         url = reverse('teacher_dashboard.views.dashboard_view', args=[self.course.id])
@@ -85,12 +97,13 @@ class TeacherDashboardViewsTests(ModuleStoreTestCase):
 
     def test_authenticated_teacher_view(self):
         """
-        Asserts that an authenticated user can see the Teacher Dashboard.
+        Asserts that an authenticated user can see Teacher Dashboard.
         """
-        url = reverse('teacher_dashboard.views.dashboard_view', args=[self.course.id])
-        response = self.client.get(url)
-        self.assertEquals(response.status_code, 200)
-        self.assertIn('teacher-dashboard', response.content)
+        for course_id in (self.course.id, self.ccx_key):
+            url = reverse('teacher_dashboard.views.dashboard_view', args=[self.course.id])
+            response = self.client.get(url, follow=True)
+            self.assertEquals(response.status_code, 200)
+            self.assertIn('teacher-dashboard', response.content)
 
     @data(
         {'type': 'licenses'},
@@ -161,8 +174,7 @@ class TeacherDashboardViewsTests(ModuleStoreTestCase):
         override_field_for_ccx(self.ccx, self.course, 'lti_passports', ccx_passports)
 
         url = reverse(
-            'teacher_dashboard.views.teacher_dahsboard_handler',
-            args=[CCXLocator.from_course_locator(self.course.id, self.ccx.id)]
+            'teacher_dashboard.views.teacher_dahsboard_handler', args=[self.ccx_key]
         )
         response = self.client.post(url, data={'type': 'licenses'})
 

--- a/lms/djangoapps/teacher_dashboard/utils.py
+++ b/lms/djangoapps/teacher_dashboard/utils.py
@@ -64,10 +64,8 @@ def _send_request(url, method=None, data=None, params=None, headers=None):
 def has_teacher_access(user, course):
     """
     Returns True when:
-        Teached dashboard feature is enabled
+        Teacher dashboard feature is enabled
         AND (
-            user has staff role
-            OR (
                 CCX feature is enabled AND user has coach role
             )
         )
@@ -75,16 +73,8 @@ def has_teacher_access(user, course):
     if not (user and settings.LABSTER_FEATURES.get('ENABLE_TEACHER_DASHBOARD', False)):
         return False
 
-    # Displays tab for course staff.
-    if bool(has_access(user, 'staff', course, course.id)):
-        return True
-
-    # The tab is hidden if the user is not staff and CCX feature is disabled.
+    # The tab is hidden if CCX feature is disabled.
     if not (settings.FEATURES.get('CUSTOM_COURSES_EDX', False) and course.enable_ccx):
         return False
 
-    ccx = get_ccx_from_ccx_locator(course.id)
-    if ccx:
-        return CourseCcxCoachRole(ccx.course_id).has_user(user)
-
-    return False
+    return CourseCcxCoachRole(course.id).has_user(user)


### PR DESCRIPTION
Display teacher dashboard for CCX in Master Courses, because all the managment tabs are there (CCX Coach, License).
It was in CCX before. 
@den99f @auraz please review.
@sidorovdmitry FYI.
