### PR TITLE
WEB-576. fix license apply error

### DIFF
--- a/lms/djangoapps/labster_course_license/utils.py
+++ b/lms/djangoapps/labster_course_license/utils.py
@@ -61,7 +61,7 @@ def get_simulation_id(uri):
     """
     Returns Simulation id extracted from the passed URI.
     """
-    return urlparse(uri).path.strip('/').split('/')[-1]
+    return urlparse(uri).path.strip(' /').split('/')[-1]
 
 
 def get_parent_unit(xblock):


### PR DESCRIPTION
https://liv-it.atlassian.net/browse/WEB-576

This bug occures in the case when LTI URL has space(s) in the end
Thus `get_simulation_id` method returns `simulation_id` as empty value

@polesye @madyasiwi please review
@auraz FYI
