### PR TITLE
WEB-558: Update License Django app do not hide non-simulation modules.

### DIFF
--- a/lms/djangoapps/labster_course_license/tests/test_views.py
+++ b/lms/djangoapps/labster_course_license/tests/test_views.py
@@ -1,5 +1,6 @@
 """
-Tests labster course license views
+Tests labster course license views.
+./manage.py lms test --verbosity=1 lms/djangoapps/labster_course_license   --traceback --settings=labster_test
 """
 import random
 import string
@@ -12,28 +13,6 @@ from openedx.core.djangoapps.labster.tests.base import CCXCourseTestBase
 from xmodule.modulestore.tests.factories import ItemFactory
 
 
-def item_factory(store, valid=True):
-    """
-    Return simulation with specified parameters.
-    """
-    simulation_id = 'a0Kw000000{}'.format(
-        ''.join(random.choice(string.ascii_uppercase + string.digits) for num in range(8))
-    )
-    url = 'https://example.com/simulation/{}/'.format(simulation_id)
-    if not valid:
-        url = '	{}	'.format(url)
-    ItemFactory.create(
-        category='lti',
-        modulestore=store,
-        display_name='LTI%s' % simulation_id,
-        metadata={
-            'lti_id': 'correct_lti_id',
-            'launch_url': url
-        }
-    )
-    return simulation_id
-
-
 class TestSetLicense(CCXCourseTestBase):
     """
     Tests for set_license method.
@@ -41,46 +20,134 @@ class TestSetLicense(CCXCourseTestBase):
 
     def setUp(self):
         super(TestSetLicense, self).setUp()
-        self.request_factory = RequestFactory()
-        self.license = 'YildVfefwmrTwNPPeapcNrugbkyb34sFoKiolPtk'
         self.url = reverse("labster_license_handler", kwargs={'course_id': self.ccx_key})
-        self.data = {'license': self.license, 'update': True}
-        self.client = Client()
+        self.data = {'license': 'YildVfefwmrTwNPPeapcNrugbkyb34sFoKiolPtk', 'update': True}
         self.client.login(username=self.user.username, password="test")
 
     @mock.patch('labster_course_license.views.get_licensed_simulations')
     @mock.patch('labster_course_license.views.get_consumer_secret')
-    def test_valid_simulation_ids(self, get_consumer_secret, get_licensed_simulations):
+    def test_valid_simulation_ids(self, mock_get_consumer_secret, mock_get_licensed_simulations):
         """
         Test that the licence page is returned with no invalid simulations.
         """
-        # create 5 lti xmodules with valid launch urls
-        licenced_simulations = []
-        for num in range(5):
-            licenced_simulations.append(item_factory(self.store))
-        get_consumer_secret.return_value = ('123', '__secret_key__')
-        get_licensed_simulations.return_value = licenced_simulations
+        mock_get_consumer_secret.return_value = ('123', '__secret_key__')
+        mock_get_licensed_simulations.return_value = ['*']
+        # create 3 lti xmodules with valid launch urls
+        data = [
+            ('https://example.com/simulation/a0Kw0000000/', 'LTI0'),
+            ('https://example.com/simulation/a0Kw0000001/', 'LTI1'),
+            ('https://example.com/simulation/a0Kw00000002', 'LTI2'),
+        ]
+        licenced_simulations = [ItemFactory.create(
+            category='lti', modulestore=self.store, display_name=display_name,
+            metadata={'lti_id': 'correct_lti_id', 'launch_url': url}
+        ) for url, display_name in data]
+
         res = self.client.post(self.url, data=self.data, follow=True)
+
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertIn(self.license, res.content)
-        self.assertNotIn('Please verify LTI URLs  are correct for the following simulations', res.content)
+        self.assertNotIn('Please verify LTI URLs are correct for the following simulations', res.content)
 
     @mock.patch('labster_course_license.views.get_licensed_simulations')
     @mock.patch('labster_course_license.views.get_consumer_secret')
-    def test_invalid_simulation_ids(self, get_consumer_secret, get_licensed_simulations):
+    def test_hides_unlicensed_simulations(self, mock_get_consumer_secret, mock_get_licensed_simulations):
+        """
+        Ensure hides only unlicensed simulations.
+        """
+        mock_get_consumer_secret.return_value = ('123', '__secret_key__')
+        mock_get_licensed_simulations.return_value = ['a0Kw0000000']
+
+        data = [
+            ('https://example.com/simulation/a0Kw0000000/', 'LTI0'),
+            ('https://example.com/dashboards/teacher/', 'LTI1'),
+            ('http://127.0.0.1/some/path/here/', 'LTI2'),
+            ('https://example.com/simulation/a0Kw0000055', 'LTI3'),
+            ('https://example.com/simulation/a0Kw0000035', 'LTI4'),
+        ]
+
+        chapter = ItemFactory.create(parent=self.course, category='chapter')
+        sequential = ItemFactory.create(parent=chapter, category='sequential')
+        verticals = [ItemFactory.create(parent=sequential, category='vertical') for i in range(len(data))]
+
+        blocks = [ItemFactory.create(
+            parent=verticals[index],
+            category='lti', modulestore=self.store, display_name=item[1],
+            metadata={'lti_id': 'correct_lti_id', 'launch_url': item[0]}
+        ) for index, item in enumerate(data)]
+
+        self.inject_field_overrides()
+        res = self.client.post(self.url, data=self.data, follow=True)
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        chapter = self.ccx.course.get_children()[0]
+        self.assertFalse(chapter.visible_to_staff_only)
+        sequential = chapter.get_children()[0]
+        self.assertFalse(sequential.visible_to_staff_only)
+        verticals = sequential.get_children()
+        self.assertEqual([False, False, False, True, True], [i.visible_to_staff_only for i in verticals])
+
+    @mock.patch('labster_course_license.views.get_licensed_simulations')
+    @mock.patch('labster_course_license.views.get_consumer_secret')
+    def test_can_hide_all_blocks(self, mock_get_consumer_secret, mock_get_licensed_simulations):
+        """
+        Test can hide all the blocks if there are no licensed simulations.
+        """
+        mock_get_consumer_secret.return_value = ('123', '__secret_key__')
+        mock_get_licensed_simulations.return_value = []
+
+        data = [
+            ('https://example.com/simulation/a0Kw0000000/', 'LTI0'),
+            ('https://example.com/dashboards/teacher/', 'LTI1'),
+            ('http://127.0.0.1/some/path/here/', 'LTI2'),
+            ('https://example.com/simulation/a0Kw0000055', 'LTI3'),
+        ]
+
+        chapter = ItemFactory.create(parent=self.course, category='chapter')
+        sequential = ItemFactory.create(parent=chapter, category='sequential')
+        verticals = [ItemFactory.create(parent=sequential, category='vertical') for i in range(len(data))]
+
+        blocks = [ItemFactory.create(
+            parent=verticals[index],
+            category='lti', modulestore=self.store, display_name=item[1],
+            metadata={'lti_id': 'correct_lti_id', 'launch_url': item[0]}
+        ) for index, item in enumerate(data)]
+
+        self.inject_field_overrides()
+        res = self.client.post(self.url, data=self.data, follow=True)
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        chapter = self.ccx.course.get_children()[0]
+        self.assertTrue(chapter.visible_to_staff_only)
+
+    @mock.patch('labster_course_license.views.get_licensed_simulations')
+    @mock.patch('labster_course_license.views.get_consumer_secret')
+    def test_invalid_simulation_ids(self, mock_get_consumer_secret, mock_get_licensed_simulations):
         """
         Test that license page is returned with error containing invalid simulations.
         """
-        # create 5 lti xmodules with few invalid launch urls
-        licenced_simulations = []
-        is_valid = [True, True, False, True, False]
-        for valid in is_valid:
-            licenced_simulations.append(item_factory(self.store, valid))
-        get_consumer_secret.return_value = ('123', '__secret_key__')
-        get_licensed_simulations.return_value = licenced_simulations
-        res = self.client.post(self.url, data=self.data, follow=True)
-        self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertIn(self.license, res.content)
-        self.assertIn('Please verify LTI URLs  are correct for the following simulations', res.content)
-        self.assertIn(licenced_simulations[2], res.content)
-        self.assertIn(licenced_simulations[4], res.content)
+        mock_get_consumer_secret.return_value = ('123', '__secret_key__')
+        mock_get_licensed_simulations.return_value = ["*"]
+
+        data = [
+            ('https://example.com/simulation/a0Kw0000000 /', 'LTI0', 'a0Kw0000000 '),
+            ('https://example.com/simulation/a0Kw0000001 ', 'LTI1', 'a0Kw0000001 '),
+            ('https://example.com/simulation/ a0Kw0000002/', 'LTI2', ' a0Kw0000002'),
+            ('https://example.com/simulation/   a0Kw00000003  /', 'LTI3', '   a0Kw00000003  '),
+            ('https://example.com/simulation/a0Kw0000 004/', 'LTI4', 'a0Kw0000 004'),
+            ('/simulation/a0Kw0000005', 'LTI5', 'a0Kw0000005'),
+            ('localhost/simulation/a0Kw0000006/', 'LTI6', 'a0Kw0000006'),
+        ]
+        licenced_simulations = [ItemFactory.create(
+            category='lti', modulestore=self.store, display_name=display_name,
+            metadata={'lti_id': 'correct_lti_id', 'launch_url': url}
+        ) for url, display_name, __ in data]
+
+        resp = self.client.post(self.url, data=self.data, follow=True)
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(7, resp.content.count('Enter a valid value.'))
+        self.assertEqual(5, resp.content.count('Enter a valid simulation id.'))
+
+        for item in data:
+            self.assertContains(resp, item[1])  # Display name
+            self.assertContains(resp, item[2])  # Simulation id

--- a/openedx/core/djangoapps/labster/tests/base.py
+++ b/openedx/core/djangoapps/labster/tests/base.py
@@ -1,14 +1,22 @@
 """
 Base classes for labster tests.
 """
+import mock
+from django.test.utils import override_settings
+
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, TEST_DATA_SPLIT_MODULESTORE
 from ccx.tests.factories import CcxFactory
 from ccx_keys.locator import CCXLocator
 from student.roles import CourseCcxCoachRole
-from student.tests.factories import UserFactory
+from student.tests.factories import UserFactory, AdminFactory
+from lms.djangoapps.courseware.tests.test_field_overrides import inject_field_overrides
+from lms.djangoapps.ccx.tests.test_views import iter_blocks
+from request_cache.middleware import RequestCache
+from courseware.field_overrides import OverrideFieldData  # pylint: disable=import-error
 
 
+@override_settings(FIELD_OVERRIDE_PROVIDERS=('ccx.overrides.CustomCoursesForEdxOverrideProvider',))
 class CCXCourseTestBase(ModuleStoreTestCase):
 
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
@@ -30,6 +38,31 @@ class CCXCourseTestBase(ModuleStoreTestCase):
         self.make_coach()
         self.ccx = self.make_ccx()
         self.ccx_key = CCXLocator.from_course_locator(self.course.id, self.ccx.id)
+
+        patch = mock.patch('ccx.overrides.get_current_ccx')
+        self.get_ccx = get_ccx = patch.start()
+        get_ccx.return_value = self.ccx
+        self.addCleanup(patch.stop)
+
+        self.addCleanup(RequestCache.clear_request_cache)
+
+
+    def inject_field_overrides(self):
+        """
+        Apparently the test harness doesn't use LmsFieldStorage, and I'm
+        not sure if there's a way to poke the test harness to do so.  So,
+        we'll just inject the override field storage in this brute force
+        manner.
+        """
+        inject_field_overrides(iter_blocks(self.ccx.course), self.course, AdminFactory.create())
+
+        def cleanup_provider_classes():
+            """
+            After everything is done, clean up by un-doing the change to the
+            OverrideFieldData object that is done during the wrap method.
+            """
+            OverrideFieldData.provider_classes = None
+        self.addCleanup(cleanup_provider_classes)
 
     def make_lti_passports(self, consumer_keys):
         """


### PR DESCRIPTION
**Ticket:** https://liv-it.atlassian.net/browse/WEB-558

Skips all lti modules that are not simulations (for instance, Teacher Dashboard, Student Dashboard, etc.).
Updates validation logic.

@TamoshaytisV @avkoval please review.
