### PR TITLE
WEB-892: Fix overrides in CCX that produces 404 in some cases.

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -56,6 +56,7 @@ from lms.djangoapps.ccx.models import CustomCourseForEdX
 from lms.djangoapps.ccx.overrides import (
     get_override_for_ccx,
     override_field_for_ccx,
+    clear_override_for_ccx,
     clear_ccx_field_info_from_ccx_map,
     bulk_delete_ccx_override_fields,
 )
@@ -263,8 +264,10 @@ def save_ccx(request, course, ccx=None):
 
         for unit in data:
             block = blocks[unit['location']]
-            override_field_for_ccx(
-                ccx, block, 'visible_to_staff_only', unit['hidden'])
+            if unit['hidden']:  # start changes by labster
+                override_field_for_ccx(ccx, block, 'visible_to_staff_only', unit['hidden'])
+            else:
+                clear_override_for_ccx(ccx, block, 'visible_to_staff_only')  # end changes by labster
 
             start = parse_date(unit['start'])
             if start:

--- a/lms/djangoapps/labster_course_license/migrations/0001_fix_ccx_overrides.py
+++ b/lms/djangoapps/labster_course_license/migrations/0001_fix_ccx_overrides.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def forwards(apps, schema_editor):
+    """
+    Removes all field overrides for `visible_to_staff_only=False` field (visible for all).
+    In this case, the value from Master course is taken.
+
+    It solves the issue when the block becomes hidden in Master Course, but is still
+    displayed in CCX that causes Permission Denied error in ModuleRender system (access is
+    restricted in Master Course).
+
+    This migration solves the issue for old courses. On the way to avoid similar
+    problem in future, additional changes have been added in:
+     * lms/djangoapps/labster_course_license/views.py:98
+     * lms/djangoapps/ccx/views.py:267-270
+    """
+    CcxFieldOverride = apps.get_model("ccx", "CcxFieldOverride")
+
+    qs = CcxFieldOverride.objects.filter(
+        field="visible_to_staff_only", value=False
+    )
+    count = qs.count()
+    qs.delete()
+    print "%d fields has been removed.s" % count
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ccx', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, migrations.RunPython.noop)
+    ]

--- a/lms/djangoapps/labster_course_license/urls.py
+++ b/lms/djangoapps/labster_course_license/urls.py
@@ -6,6 +6,8 @@ from django.conf.urls import patterns, url
 
 urlpatterns = patterns(
     '',
-    url(r'^labster_license/?$',
-        'labster_course_license.views.license_handler', name='labster_license_handler'),
+    url(
+        r'^labster_license/?$',
+        'labster_course_license.views.license_handler', name='labster_license_handler'
+    ),
 )

--- a/lms/envs/labster_test.py
+++ b/lms/envs/labster_test.py
@@ -6,13 +6,20 @@ LABSTER_FEATURES = {
     "ENABLE_VOUCHERS": False,
 }
 
-INSTALLED_APPS += (
+LABSTER_APPS = (
     'labster_course_license',
     'labster_vouchers',
 )
 
+INSTALLED_APPS += LABSTER_APPS
+
+MIGRATION_MODULES.update({
+    app: "app.migrations_not_used_in_tests" for app in LABSTER_APPS
+})
+
 FEATURES['SHOW_LABSTER_NOTIFICATION'] = False
 LABSTER_WIKI_LINK = 'https://theory.example.com/'
+
 LABSTER_API_AUTH_TOKEN = ''
 
 LABSTER_API_URL = ''


### PR DESCRIPTION
https://liv-it.atlassian.net/browse/WEB-892

The issue that the edX doesn't handle correctly situation when the block in Master course has `visible_to_staff_only = True` and `visible_to_staff_only = False` override in the CCX.
In this case, edX display the section and return 404 when the student runs simulation.

Fix:
* Migration script that remove all `False` values in overrides for `visible_to_staff_only` field.
* The logic is updated to clear override if `visible_to_staff_only` is updated to `False`. In this case, it inherits the value from Master course.

@TamoshaytisV @auraz please review.

Simple way to check:
1. Go to Master Course -> Coach tab. 
2. Add some section to the CCX and Save changes.
3. Make sure it's visible under STUDENT account.
4. Go to Studio and mark this section as `visible to staff only`.
5. Go back to the course as a STUDENT and make sure the section is invisible.
