### PR TITLE
WEB-382: Fix indentation issues in activation email.

### DIFF
--- a/themes/courses.labster.com/lms/templates/emails/activation_email.txt
+++ b/themes/courses.labster.com/lms/templates/emails/activation_email.txt
@@ -1,0 +1,20 @@
+<%namespace file="../main.html" import="stanford_theme_enabled" />
+<%! from django.utils.translation import ugettext as _ %>
+${_("Thank you for signing up for {platform_name}.").format(platform_name=settings.PLATFORM_NAME)}
+
+${_("Change your life and start learning today by activating your "
+    "{platform_name} account. Click on the link below or copy and "
+    "paste it into your browser's address bar.").format(
+      platform_name=settings.PLATFORM_NAME
+    )}
+
+% if is_secure:
+https://${ site }/activate/${ key }
+% else:
+http://${ site }/activate/${ key }
+% endif
+
+${_("If you didn't request this, you don't need to do anything; you won't "
+"receive any more email from us. Please do not reply to this e-mail; "
+"if you require assistance, check the help section of the "
+"{platform_name} website.").format(platform_name=settings.PLATFORM_NAME)}


### PR DESCRIPTION
https://liv-it.atlassian.net/browse/WEB-382

Issue:
Not needed by labster `if` statements add extra whitespaces. 

Fix:
* default template is overriden in Comprehensive theme.
* Removed not needed `if` statements.

@TamoshaytisV @leha2000 please review