### PR TITLE
WEB-794: fix and change the course_key in get_user_role

### DIFF
--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -881,17 +881,14 @@ def get_user_role(user, course_key):
     # Check if user is a coach on this ccx.
     ccx_coach_role = False  # Added by labster
     if isinstance(course_key, CCXLocator):
-        try:
-            ccx = CustomCourseForEdX.objects.get(pk=course_key.ccx)
-            if CourseCcxCoachRole(ccx.course_id).has_user(user):
-                list_ccx = CustomCourseForEdX.objects.filter(
-                    course_id=course_key.to_course_locator(),
-                    coach=user
-                )
-                if list_ccx.exists():
-                    ccx_coach_role = str(list_ccx[0].id) == str(course_key.ccx)
-        except CCXLocatorValidationException as err:
-            pass  # Added by labster
+        ccx = CustomCourseForEdX.objects.get(pk=course_key.ccx)
+        if CourseCcxCoachRole(ccx.course_id).has_user(user):
+            list_ccx = CustomCourseForEdX.objects.filter(
+                course_id=course_key.to_course_locator(),
+                coach=user
+            )
+            if list_ccx.exists():
+                ccx_coach_role = str(list_ccx[0].id) == str(course_key.ccx)
 
     if role:
         return role

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -878,12 +878,18 @@ def get_user_role(user, course_key):
     """
     role = get_masquerade_role(user, course_key)
 
-
     # Check if user is a coach on this ccx.
-    ccx_coach_role = False # Added by labster
+    ccx_coach_role = False  # Added by labster
     if isinstance(course_key, CCXLocator):
         try:
-            ccx_coach_role = has_ccx_coach_role(user, course_key)
+            ccx = CustomCourseForEdX.objects.get(pk=course_key.ccx)
+            if CourseCcxCoachRole(ccx.course_id).has_user(user):
+                list_ccx = CustomCourseForEdX.objects.filter(
+                    course_id=course_key.to_course_locator(),
+                    coach=user
+                )
+                if list_ccx.exists():
+                    ccx_coach_role = str(list_ccx[0].id) == str(course_key.ccx)
         except CCXLocatorValidationException as err:
             pass  # Added by labster
 

--- a/lms/djangoapps/courseware/tests/test_access_labster.py
+++ b/lms/djangoapps/courseware/tests/test_access_labster.py
@@ -40,7 +40,6 @@ class UserRoleTestCase(SharedModuleStoreTestCase):
         ccx.save()
 
         ccx_locator = CCXLocator.from_course_locator(course.id, unicode(ccx.id))
-        self.make_coach(coach, ccx_locator)
         CourseEnrollment.enroll(coach, ccx_locator)
 
         return ccx_locator
@@ -60,6 +59,10 @@ class UserRoleTestCase(SharedModuleStoreTestCase):
         # Create ccx
         self.ccx_locator = self.make_ccx(self.coach, self.course, "Test CCX")
         self.ccx_locator2 = self.make_ccx(self.coach2, self.course2, "Test CCX2")
+
+        # assign role to coach
+        self.make_coach(self.coach, self.course.id)
+        self.make_coach(self.coach2, self.course2.id)
 
     def test_user_role_instructor(self):
         """


### PR DESCRIPTION
When a teacher is a student of other course, currently, the Student Dashboard is opened when the user opens it as a student of the course. 

However, when the user opens the Dashboard as the Teacher of his own CCX Course, it will open Student Dashboard instead of Teacher Dashboard.