### PR TITLE
WEB-1506 Extend enrollment logging

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -962,6 +962,8 @@ class CourseEnrollment(models.Model):
             enrollment.is_active = False
             enrollment.save()
 
+        log.info("User %s enrolled to course %s", user.email, course_key)
+
         return enrollment
 
     @classmethod

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -647,6 +647,10 @@ def ccx_student_management(request, course, ccx=None):
     email_params = get_email_params(course, auto_enroll=True, course_key=course_key, display_name=ccx.display_name)
 
     errors = _ccx_students_enrrolling_center(action, identifiers, email_students, course_key, email_params)
+    log.info(
+        "User: %s;\nAction: %s;\nIdentifiers: %s;\nSend email: %s;\nCourse: %s;\nEmail parameters: %s.",
+        request.user, action, identifiers, email_students, course_key, email_params
+    )
 
     for error_message in errors:
         messages.error(request, error_message)


### PR DESCRIPTION
Added logging for enrollment of individual students in a CCX. Also added logging to CourseEnrollment model method which is called on every enrollment. It will allow tracking at least that enrollment has happened (no info about coach) but this logs will appear next to other coach actions

@polesye @lukyfebrianto please review