### PR TITLE
Fix: sync urls with labster/develop branch

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -939,6 +939,7 @@ urlpatterns += (
 
 urlpatterns += (
     url(r'^vouchers/', include('labster_vouchers.urls')),
+    url(r'^labster/api/', include('lms.djangoapps.labster_enroll.urls')),
 )
 
 # Certificates


### PR DESCRIPTION
During upgrade to eucalyptus lms.urls were not merged completely

@polesye @leha2000 please check