### PR TITLE
[WEB-1892]: License Reorganization: Send Linense as a custom parameter.

### DIFF
--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -393,10 +393,10 @@ class LTIModule(LTIFields, LTI20ModuleMixin, XModule):
                 param_name = 'custom_' + param_name
 
             custom_parameters[unicode(param_name)] = unicode(param_value)
-
+        # Start Changes by Labster: To simplify license applying UX
         if license and 'custom_license' not in custom_parameters:
             custom_parameters[u'custom_license'] = unicode(license)
-
+        # End Changes by Labster: To simplify license applying UX
         return self.oauth_params(
             custom_parameters,
             client_key,
@@ -883,12 +883,14 @@ oauth_consumer_key="", oauth_signature="frVp4JuvT1mVXlxktiAUjQ7%2F1cw%3D"'}
         course = self.get_course()
         for lti_passport in course.lti_passports:
             try:
+                # Start Changes by Labster: To simplify license applying UX
                 values = [i.strip() for i in lti_passport.split(':')]
                 if len(values) === 4:  # new Labster passport LTI format
                     lti_id, key, secret, license = values
                 else:
                     lti_id, key, secret = values
                     license = None
+                # End Changes by Labster: To simplify license applying UX
             except ValueError:
                 _ = self.runtime.service(self, "i18n").ugettext
                 msg = _('Could not parse LTI passport: {lti_passport}. Should be "id:key:secret" string.').format(
@@ -898,7 +900,7 @@ oauth_consumer_key="", oauth_signature="frVp4JuvT1mVXlxktiAUjQ7%2F1cw%3D"'}
 
             if lti_id == self.lti_id.strip():
                 return key, secret, license
-        return '', ''
+        return '', '', ''
 
     def is_past_due(self):
         """

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -885,7 +885,7 @@ oauth_consumer_key="", oauth_signature="frVp4JuvT1mVXlxktiAUjQ7%2F1cw%3D"'}
             try:
                 # Start Changes by Labster: To simplify license applying UX
                 values = [i.strip() for i in lti_passport.split(':')]
-                if len(values) === 4:  # new Labster passport LTI format
+                if len(values) == 4:  # new Labster passport LTI format
                     lti_id, key, secret, license = values
                 else:
                     lti_id, key, secret = values

--- a/lms/envs/labster.py
+++ b/lms/envs/labster.py
@@ -30,7 +30,7 @@ LABSTER_API_AUTH_TOKEN = LABSTER_AUTH.get('LABSTER_API_AUTH_TOKEN', '')
 LABSTER_API_URL = LABSTER_SETTINGS.get('LABSTER_API_URL', '')
 LABSTER_ENDPOINTS = {
     'available_simulations': '',
-    'keys': '',
+    'license_validate': '',
     'voucher_license': '',
     'voucher_activate': '',
 }

--- a/lms/envs/labster.py
+++ b/lms/envs/labster.py
@@ -30,7 +30,7 @@ LABSTER_API_AUTH_TOKEN = LABSTER_AUTH.get('LABSTER_API_AUTH_TOKEN', '')
 LABSTER_API_URL = LABSTER_SETTINGS.get('LABSTER_API_URL', '')
 LABSTER_ENDPOINTS = {
     'available_simulations': '',
-    'license': '',
+    'keys': '',
     'voucher_license': '',
     'voucher_activate': '',
 }

--- a/lms/envs/labster.py
+++ b/lms/envs/labster.py
@@ -30,7 +30,7 @@ LABSTER_API_AUTH_TOKEN = LABSTER_AUTH.get('LABSTER_API_AUTH_TOKEN', '')
 LABSTER_API_URL = LABSTER_SETTINGS.get('LABSTER_API_URL', '')
 LABSTER_ENDPOINTS = {
     'available_simulations': '',
-    'consumer_secret': '',
+    'license': '',
     'voucher_license': '',
     'voucher_activate': '',
 }

--- a/lms/envs/labster_test.py
+++ b/lms/envs/labster_test.py
@@ -27,7 +27,7 @@ LABSTER_API_AUTH_TOKEN = ''
 LABSTER_API_URL = ''
 LABSTER_ENDPOINTS = {
     'available_simulations': 'https://example.com/available_simulations',
-    'consumer_secret': 'https://example.com/consumer_secret',
+    'keys': 'https://example.com/keys',
     'voucher_license': 'https://example.com/vouchers/{}/license/',
     'voucher_activate': 'https://example.com/voucher/activate/',
 }

--- a/lms/envs/labster_test.py
+++ b/lms/envs/labster_test.py
@@ -27,7 +27,7 @@ LABSTER_API_AUTH_TOKEN = ''
 LABSTER_API_URL = ''
 LABSTER_ENDPOINTS = {
     'available_simulations': 'https://example.com/available_simulations',
-    'keys': 'https://example.com/keys',
+    'license_validate': 'https://example.com/licenses/validate/',
     'voucher_license': 'https://example.com/vouchers/{}/license/',
     'voucher_activate': 'https://example.com/voucher/activate/',
 }

--- a/lms/templates/labster/course_license.html
+++ b/lms/templates/labster/course_license.html
@@ -66,7 +66,7 @@ from django.core.urlresolvers import reverse
           )}
         </p>
       %else:
-        <% license_code = license.license_code if license else '' %>
+        <% license_code = license or '' %>
         <form action="${labster_license_url}" method="POST">
           <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
           <p>

--- a/lms/templates/labster/course_license.html
+++ b/lms/templates/labster/course_license.html
@@ -67,18 +67,18 @@ from django.core.urlresolvers import reverse
         </p>
       %else:
         <% license_code = license.license_code if license else '' %>
-        <% consumer_key = consumer_key or '' %>
-        <% secret_key = secret_key or '' %>
+        <% consumer_key_value = consumer_key or '' %>
+        <% secret_key_value = secret_key or '' %>
         <form action="${labster_license_url}" method="POST">
           <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
           <p>
             <label for="labster-consumer">${_("Consumer key:")}</label>
-            <input type="text" id="labster-consumer" name="consumer_key" value="${consumer_key}"
+            <input type="text" id="labster-consumer" name="consumer_key" value="${consumer_key_value}"
               placeholder="${_('Enter your Consumer Key')}" style="width:50%" required />
           </p>
           <p>
             <label for="labster-secret">${_("Secret key:")}</label>
-            <input type="text" id="labster-secret" name="secret_key" value="${secret_key}"
+            <input type="text" id="labster-secret" name="secret_key" value="${secret_key_value}"
               placeholder="${_('Enter your Secret Key')}" style="width:50%" required />
           </p>
           <p>

--- a/lms/templates/labster/course_license.html
+++ b/lms/templates/labster/course_license.html
@@ -66,24 +66,21 @@ from django.core.urlresolvers import reverse
           )}
         </p>
       %else:
-        <% license_code = license.license_code if license else '' %>
-        <% consumer_key_value = consumer_key or '' %>
-        <% secret_key_value = secret_key or '' %>
         <form action="${labster_license_url}" method="POST">
           <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
           <p>
             <label for="labster-consumer">${_("Consumer key:")}</label>
-            <input type="text" id="labster-consumer" name="consumer_key" value="${consumer_key_value}"
+            <input type="text" id="labster-consumer" name="consumer_key" value="${consumer_key}"
               placeholder="${_('Enter your Consumer Key')}" style="width:50%" required />
           </p>
           <p>
             <label for="labster-secret">${_("Secret key:")}</label>
-            <input type="text" id="labster-secret" name="secret_key" value="${secret_key_value}"
+            <input type="text" id="labster-secret" name="secret_key" value="${secret_key}"
               placeholder="${_('Enter your Secret Key')}" style="width:50%" required />
           </p>
           <p>
             <label for="labster-license">${_("License:")}</label>
-            <input type="text" id="labster-license" name="license" value="${license_code}"
+            <input type="text" id="labster-license" name="license" value="${license}"
               placeholder="${_('Enter your license')}" style="width:50%" required />
           </p>
           <p><button type="submit">${_("Apply")}</button></p>

--- a/lms/templates/labster/course_license.html
+++ b/lms/templates/labster/course_license.html
@@ -71,17 +71,17 @@ from django.core.urlresolvers import reverse
           <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
           <p>
             <label for="labster-consumer">${_("Consumer key:")}</label>
-            <input type="text" id="labster-consumer" name="consumer_key" value="${consumer_key}"
+            <input type="text" id="labster-consumer" name="consumer_key" value="${consumer_key|default:''}"
               placeholder="${_('Enter your Consumer Key')}" style="width:50%" required />
           </p>
           <p>
             <label for="labster-secret">${_("Secret key:")}</label>
-            <input type="text" id="labster-secret" name="secret_key" value="${secret_key}"
+            <input type="text" id="labster-secret" name="secret_key" value="${secret_key|default:''}"
               placeholder="${_('Enter your Secret Key')}" style="width:50%" required />
           </p>
           <p>
             <label for="labster-license">${_("License:")}</label>
-            <input type="text" id="labster-license" name="license" value="${license_code}"
+            <input type="text" id="labster-license" name="license" value="${license_code|default:''}"
               placeholder="${_('Enter your license')}" style="width:50%" required />
           </p>
           <p><button type="submit">${_("Apply")}</button></p>

--- a/lms/templates/labster/course_license.html
+++ b/lms/templates/labster/course_license.html
@@ -70,9 +70,19 @@ from django.core.urlresolvers import reverse
         <form action="${labster_license_url}" method="POST">
           <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
           <p>
+            <label for="labster-consumer">${_("Consumer key:")}</label>
+            <input type="text" id="labster-consumer" name="consumer_key" value="${consumer_key}"
+              placeholder="${_('Enter your Consumer Key')}" style="width:50%" required />
+          </p>
+          <p>
+            <label for="labster-secret">${_("Secret key:")}</label>
+            <input type="text" id="labster-secret" name="secret_key" value="${secret_key}"
+              placeholder="${_('Enter your Secret Key')}" style="width:50%" required />
+          </p>
+          <p>
             <label for="labster-license">${_("License:")}</label>
             <input type="text" id="labster-license" name="license" value="${license_code}"
-              placeholder="${_('Enter your license')}" style="width:50%" />
+              placeholder="${_('Enter your license')}" style="width:50%" required />
           </p>
           <p><button type="submit">${_("Apply")}</button></p>
         </form>

--- a/lms/templates/labster/course_license.html
+++ b/lms/templates/labster/course_license.html
@@ -66,22 +66,24 @@ from django.core.urlresolvers import reverse
           )}
         </p>
       %else:
-        <% license_code = license or '' %>
+        <% license_code = license.license_code if license else '' %>
+        <% consumer_key = consumer_key or '' %>
+        <% secret_key = secret_key or '' %>
         <form action="${labster_license_url}" method="POST">
           <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
           <p>
             <label for="labster-consumer">${_("Consumer key:")}</label>
-            <input type="text" id="labster-consumer" name="consumer_key" value="${consumer_key|default:''}"
+            <input type="text" id="labster-consumer" name="consumer_key" value="${consumer_key}"
               placeholder="${_('Enter your Consumer Key')}" style="width:50%" required />
           </p>
           <p>
             <label for="labster-secret">${_("Secret key:")}</label>
-            <input type="text" id="labster-secret" name="secret_key" value="${secret_key|default:''}"
+            <input type="text" id="labster-secret" name="secret_key" value="${secret_key}"
               placeholder="${_('Enter your Secret Key')}" style="width:50%" required />
           </p>
           <p>
             <label for="labster-license">${_("License:")}</label>
-            <input type="text" id="labster-license" name="license" value="${license_code|default:''}"
+            <input type="text" id="labster-license" name="license" value="${license_code}"
               placeholder="${_('Enter your license')}" style="width:50%" required />
           </p>
           <p><button type="submit">${_("Apply")}</button></p>

--- a/openedx/core/djangoapps/labster/tests/base.py
+++ b/openedx/core/djangoapps/labster/tests/base.py
@@ -16,7 +16,7 @@ from ccx_keys.locator import CCXLocator
 from student.roles import CourseCcxCoachRole
 from student.tests.factories import UserFactory, AdminFactory
 from lms.djangoapps.courseware.tests.test_field_overrides import inject_field_overrides
-from lms.djangoapps.ccx.tests.test_views import iter_blocks
+from lms.djangoapps.ccx.tests.utils import iter_blocks
 from request_cache.middleware import RequestCache
 from courseware.field_overrides import OverrideFieldData  # pylint: disable=import-error
 
@@ -82,7 +82,7 @@ class CCXCourseTestBase(ModuleStoreTestCase):
         Create lti passports.
         """
         return [
-            ':'.join(['TEST-' + str(i), k, '__secret_key__'])
+            ':'.join(['TEST-' + str(i), k, '__secret_key__','__license__'])
             for i, k in enumerate(consumer_keys)
         ]
 


### PR DESCRIPTION
As a part of License Reorganization project, a license should be sent as LTI custom parameter when available. It will help simplify UX and avoid 1 extra step (license selection).


Relates to: https://github.com/Livit/Livit.Learn.EdxCourseLicenses/pull/6