### PR TITLE
WEB-1814 support course codes

### DIFF
--- a/lms/djangoapps/labster_vouchers/tasks.py
+++ b/lms/djangoapps/labster_vouchers/tasks.py
@@ -34,7 +34,7 @@ def activate_voucher(voucher, user_id, email, context_id):
         response.raise_for_status()
     except RequestException as ex:
         msg = (
-            "Issues with voucher activation: user_id='%s', email='%s', "
+            "Issues with access code activation: user_id='%s', email='%s', "
             "context_id='%s', voucher='%s',\nerror:\n%r"
         )
         log.exception(msg, user_id, email, context_id, voucher, ex)

--- a/lms/djangoapps/labster_vouchers/views.py
+++ b/lms/djangoapps/labster_vouchers/views.py
@@ -104,7 +104,7 @@ def activate_voucher(request):
         return redirect(enter_voucher_url)
     except LabsterApiError:
         messages.error(request, _(
-            "There are some issues with applying your acess code. Please try again in a few minutes."
+            "There are some issues with applying your access code. Please try again in a few minutes."
         ))
         return redirect(enter_voucher_url)
 

--- a/lms/djangoapps/labster_vouchers/views.py
+++ b/lms/djangoapps/labster_vouchers/views.py
@@ -57,7 +57,7 @@ class VoucherError(Exception):
 @login_required
 def enter_voucher(request):
     """
-    Enter Voucher View.
+    Enter Access Code View.
     """
     if not getattr(settings, 'LABSTER_FEATURES', {}).get('ENABLE_VOUCHERS'):
         raise Http404
@@ -80,14 +80,14 @@ def activate_voucher(request):
 
     if not request.user.is_active:
         messages.error(request, _(
-            "Voucher cannot be applied, because your account has not been activated yet."
+            "Access Code cannot be applied, because your account has not been activated yet."
         ))
         return redirect(enter_voucher_url)
 
     form = forms.ValidationForm(request.POST)
 
     if not form.is_valid():
-        messages.error(request, _("Enter a valid voucher code."))
+        messages.error(request, _("Please enter a valid access code."))
         return redirect(enter_voucher_url)
 
     code = form.cleaned_data['code']
@@ -99,12 +99,12 @@ def activate_voucher(request):
         return redirect(enter_voucher_url)
     except ItemNotFoundError:
         messages.error(request, _(
-            "Cannot find a voucher '{}'. Please contact Labster support team."
+            "Cannot find an access code '{}'. Please contact Labster support team."
         ).format(code))
         return redirect(enter_voucher_url)
     except LabsterApiError:
         messages.error(request, _(
-            "There are some issues with applying your voucher. Please try again in a few minutes."
+            "There are some issues with applying your acess code. Please try again in a few minutes."
         ))
         return redirect(enter_voucher_url)
 
@@ -113,7 +113,7 @@ def activate_voucher(request):
     if not course_licenses:
         messages.error(
             request,
-            _("Cannot find a course for the voucher '{}'. Please contact Labster support team.").format(code)
+            _("Cannot find a course for provided access code '{}'. Please contact Labster support team.").format(code)
         )
         return redirect(enter_voucher_url)
 
@@ -145,11 +145,11 @@ def activate_voucher(request):
     return redirect(reverse('info', args=[unicode(course_id)]))
 
 
-def get_license(voucher):
+def get_license(access_code):
     """
-    Returns a license for the given voucher code.
+    Returns a license for the given access code.
     """
-    url = settings.LABSTER_ENDPOINTS.get('voucher_license').format(voucher)
+    url = settings.LABSTER_ENDPOINTS.get('voucher_license').format(access_code)
 
     # Send voucher code to API and get license back
     headers = {

--- a/lms/templates/labster/enter_voucher.html
+++ b/lms/templates/labster/enter_voucher.html
@@ -54,10 +54,10 @@
             <li class="field required text" id="field-name">
               <label for="code">${_('Code')}</label>
               <input id="code" type="text" name="code"
-                placeholder="${_('Please enter purchased access code')}"
+                placeholder="${_('Please enter your Voucher Code or Course Code')}"
                 required
                 aria-required="true" aria-describedby="code-tip"/>
-              <span class="tip tip-input" id="code-tip">${_("Needed for access to Labster courses")}</span>
+              <span class="tip tip-input" id="code-tip">${_("In case you have any questions please write us at support@labster.com")}</span>
             </li>
           </ol>
         </div>

--- a/lms/templates/labster/enter_voucher.html
+++ b/lms/templates/labster/enter_voucher.html
@@ -59,12 +59,7 @@
                 required
                 aria-required="true" aria-describedby="code-tip"/>
               <span class="tip tip-input" id="code-tip">
-                  ${_("In case you have any questions please write us at ")}
-                  % if settings.SUPPORT_EMAIL:
-                    ${settings.SUPPORT_EMAIL}
-                  % else:
-                    support@labster.com
-                  % endif
+                  ${_("In case you have any questions please write us at {{support_email}}}").format(support_email=settings.CONTACT_EMAIL)}
               </span>
             </li>
           </ol>

--- a/lms/templates/labster/enter_voucher.html
+++ b/lms/templates/labster/enter_voucher.html
@@ -2,6 +2,7 @@
 <%!
     from django.utils.translation import ugettext as _
     from django.core.urlresolvers import reverse
+    from django.conf import settings
 %>
 
 <%block name="pagetitle">${_("Enter access code")}</%block>
@@ -57,7 +58,14 @@
                 placeholder="${_('Please enter your Voucher Code or Course Code')}"
                 required
                 aria-required="true" aria-describedby="code-tip"/>
-              <span class="tip tip-input" id="code-tip">${_("In case you have any questions please write us at support@labster.com")}</span>
+              <span class="tip tip-input" id="code-tip">
+                  ${_("In case you have any questions please write us at ")}
+                  % if settings.SUPPORT_EMAIL:
+                    ${settings.SUPPORT_EMAIL}
+                  % else:
+                    support@labster.com
+                  % endif
+              </span>
             </li>
           </ol>
         </div>

--- a/lms/templates/labster/enter_voucher.html
+++ b/lms/templates/labster/enter_voucher.html
@@ -4,7 +4,7 @@
     from django.core.urlresolvers import reverse
 %>
 
-<%block name="pagetitle">${_("Enter voucher code")}</%block>
+<%block name="pagetitle">${_("Enter access code")}</%block>
 
 <%block name="bodyclass">view-register-voucher is-authenticated</%block>
 
@@ -26,7 +26,7 @@
         action="${reverse('activate_voucher')}"
       >
         <div class="section-title lines">
-          <h2><span class="text">${_('Enter Voucher')}</span></h2>
+          <h2><span class="text">${_('Enter Access Code')}</span></h2>
         </div>
         <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
         <!-- status messages -->
@@ -35,7 +35,7 @@
         % else:
         <div role="alert" class="status message submission-error" tabindex="-1">
         % endif
-          <h3 class="message-title">${_("The following errors occurred while processing your voucher code:")} </h3>
+          <h3 class="message-title">${_("The following errors occurred while processing your access code:")} </h3>
           % if messages:
             <div class="messages message-copy">
             % for message in messages:
@@ -54,7 +54,7 @@
             <li class="field required text" id="field-name">
               <label for="code">${_('Code')}</label>
               <input id="code" type="text" name="code"
-                placeholder="${_('Please enter purchased voucher code')}"
+                placeholder="${_('Please enter purchased access code')}"
                 required
                 aria-required="true" aria-describedby="code-tip"/>
               <span class="tip tip-input" id="code-tip">${_("Needed for access to Labster courses")}</span>

--- a/themes/courses.labster.com/lms/templates/header.html
+++ b/themes/courses.labster.com/lms/templates/header.html
@@ -79,7 +79,7 @@ site_status_msg = get_site_status_msg(course_id)
           % endif
           % if settings.LABSTER_FEATURES.get('ENABLE_VOUCHERS') and user.is_active:
             <li class="nav-global-01">
-              <a href="${reverse('enter_voucher')}">${_('Enter voucher')}</a>
+              <a href="${reverse('enter_voucher')}">${_('Enter access code')}</a>
             </li>
           % endif
           % if show_program_listing:


### PR DESCRIPTION
https://liv-it.atlassian.net/browse/WEB-1814
Related API PR:
Students should be able to enroll by course codes the same way they do with vouchers.
For this reason, we use "Enter Voucher" page. "Voucher" is renamed to "Access code" everywhere to reflect the ability to accept several types of codes.
Could be merged without API part