### PR TITLE
WEB-1907: Add github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+**Description:** Describe in a couple of sentences what this PR adds
+
+**JIRA:** Link to JIRA ticket
+
+**Merge deadline:** List merge deadline (if any)
+
+**Configuration instructions:** List any non-trivial configuration
+instructions (if any).
+
+**Testing instructions:**
+
+1. Open page A
+2. Do thing B
+3. Expect C to happen
+4. If D happened instead - check failed.
+
+**Reviewers:**
+- [ ] tag reviewer
+- [ ] tag reviewer
+
+**Merge checklist:**
+- [ ] All reviewers approved
+- [ ] CI build is green
+- [ ] Documentation updated (not only docstrings)
+- [ ] Commits are squashed
+
+**Post merge:**
+- [ ] Delete working branch (if not needed anymore)
+
+**Author concerns:** List any concerns about this PR - inelegant
+solutions, hacks, quick-and-dirty implementations, concerns about
+migrations, etc.


### PR DESCRIPTION
This PR adds default templates for PRs.

Relation PR:
- https://github.com/Livit/Livit.Learn.EdxCourseLicenses/pull/7
- https://github.com/Livit/Livit.Learn.LTI/pull/527
- https://github.com/Livit/Livit.Learn.Wiki/pull/79


Looks here for more information:
https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/
https://github.com/blog/2111-issue-and-pull-request-templates

@polesye @aldian please review it