### PR TITLE
WEB-1920: SEO: Change the Title Tags to be different.

### DIFF
--- a/themes/courses.labster.com/lms/templates/student_account/login_and_register.html
+++ b/themes/courses.labster.com/lms/templates/student_account/login_and_register.html
@@ -1,0 +1,45 @@
+<%!
+    import json
+    from django.utils.translation import ugettext as _
+    from openedx.core.djangolib.js_utils import dump_js_escaped_json
+%>
+<%namespace name='static' file='/static_content.html'/>
+
+<%inherit file="../main.html" />
+
+<%block name="pagetitle">
+    % if data['initial_mode'] == "register":
+        ${_("Register")}
+    % else:
+        ${_("Sign in")}
+    % endif
+</%block>
+
+<%block name="js_extra">
+    <%static:require_module module_name="js/student_account/logistration_factory" class_name="LogistrationFactory">
+        var options = ${data | n, dump_js_escaped_json};
+        LogistrationFactory(options);
+        if ('newrelic' in window) {
+            newrelic.finished();
+            // Because of a New Relic bug, the finished() event doesn't show up
+            // in Insights, so we have to make a new PageAction that is basically
+            // the same thing. We still want newrelic.finished() for session
+            // traces though.
+            newrelic.addPageAction('xfinished');
+        }
+    </%static:require_module>
+</%block>
+
+<%block name="header_extras">
+    % for template_name in ["account", "access", "form_field", "login", "register", "institution_login", "institution_register", "password_reset", "hinted_login"]:
+        <script type="text/template" id="${template_name}-tpl">
+            <%static:include path="student_account/${template_name}.underscore" />
+        </script>
+% endfor
+</%block>
+
+<div class="section-bkg-wrapper">
+    <main id="main" aria-label="Content" tabindex="-1">
+        <div id="login-and-registration-container" class="login-register" />
+    </main>
+</div>


### PR DESCRIPTION
**Description:** 
https://courses.labster.com/register?next=/dashboard and https://courses.labster.com/login?next=/dashboard have the same Titles: Sign in or Register | Labster, we need to change them to Register | Labster and Sign in | Labster

**JIRA:** https://liv-it.atlassian.net/browse/WEB-1920

**Testing instructions:**

1. Open page https://courses.labster.com/register?next=/dashboard . Ensure title is "Register | Labster"
2.  Open page https://courses.labster.com/login?next=/dashboard . Ensure title is "Sign In | Labster"

**Reviewers:**
- [x] tag reviewer
- [x] tag reviewer

**Merge checklist:**
- [x] All reviewers approved
- [x] Commits are squashed

**Post merge:**
- [x] Delete working branch (if not needed anymore)