### PR TITLE
WEB-1996: new simulation it doesn't automatically show in edx. [Edx]

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -66,6 +66,9 @@ from lms.djangoapps.ccx.utils import (
     prep_course_for_grading,
 )
 
+from labster_course_license.licensed_blocks_override import is_visible_to_staff_only
+
+
 log = logging.getLogger(__name__)
 TODAY = datetime.datetime.today  # for patching in tests
 
@@ -391,9 +394,16 @@ def get_ccx_schedule(course, ccx):
             if child.visible_to_staff_only:
                 continue
 
-            hidden = get_override_for_ccx(
-                ccx, child, 'visible_to_staff_only',
-                child.visible_to_staff_only)
+            # Start: Added by Labster
+            # Displays the simulations that are included in the license
+            # Check simulation visibility of staff
+            is_staff_only = is_visible_to_staff_only(ccx, child, child.visible_to_staff_only)
+            if is_staff_only:
+                continue
+
+            # Gets the value of the overridden field
+            hidden = get_override_for_ccx(ccx, child, 'visible_to_staff_only', is_staff_only)
+            # End: Added by Labster
 
             start = get_date(ccx, child, 'start')
             if depth > 1:


### PR DESCRIPTION
**Description:** When admin update and add new simulation, it doesn't automatically show in edx. User have to reapply the license

**JIRA:** https://liv-it.atlassian.net/browse/WEB-1996

**Related PR:** https://github.com/Livit/Livit.Learn.EdxCourseLicenses/pull/10

**Merge deadline:** List merge deadline (if any)

**Configuration instructions:** List any non-trivial configuration
instructions (if any).

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [x] tag reviewer
- [x] tag reviewer

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [x] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
