### PR TITLE
Change pip version

### DIFF
--- a/requirements/edx/pre.txt
+++ b/requirements/edx/pre.txt
@@ -12,7 +12,7 @@ setuptools==18.0.1
 numpy==1.6.2
 
 # Needed to make sure that options in base.txt are allowed
-pip==7.1.2
+pip==9.0.1
 
 # Needed for meliae
 Cython==0.21.2


### PR DESCRIPTION
**Description:** Update pip version to 9.0.1. Older version (7.x) breaks requirements install (at least cryptography)