### PR TITLE
WEB-2209: Fix bug button management instructor

### DIFF
--- a/lms/static/coffee/src/instructor_dashboard/membership.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/membership.coffee
@@ -29,8 +29,8 @@ class MemberListWidget
     @$container.html Mustache.render template_html, params
 
     # bind add button
-    @$('input[type="button"].add').click =>
-      params.add_handler? @$('.add-field').val()
+    @$('input[type="button"].add').click (event) =>
+      params.add_handler? @$(event.target).prev().children('.add-field').val()  # changed by labster
 
   # clear the input text field
   clear_input: -> @$('.add-field').val ''

--- a/themes/courses.labster.com/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/themes/courses.labster.com/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -11,6 +11,13 @@ from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_
       <div class="title"> {{title}} </div>
     </div>
     <div class="info"> {{info}} </div>
+    <div class="bottom-bar">
+      <label>
+          <span class="label-text sr">{{add_placeholder}}</span>
+          <input type="text" id="add-field" name="add-field" class="add-field" placeholder="{{add_placeholder}}">
+      </label>
+      <input type="button" name="add" class="add" value="{{add_btn_label}}">
+    </div>
     <div class="member-list">
       <table>
         <thead>


### PR DESCRIPTION
**Description:** One of add coach button doesn't working properly and not allow admin to add new coach/instructor

**JIRA:** https://liv-it.atlassian.net/browse/WEB-2209

**Merge deadline:** List merge deadline (if any)

**Configuration instructions:** List any non-trivial configuration
instructions (if any).

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [x] tag reviewer
- [x] tag reviewer

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
