### PR TITLE
WEB-768: Improvement/remove browse button

### DIFF
--- a/themes/courses.labster.com/lms/templates/header.html
+++ b/themes/courses.labster.com/lms/templates/header.html
@@ -72,11 +72,6 @@ site_status_msg = get_site_status_msg(course_id)
       % if user.is_authenticated():
         <ol class="left nav-global list-inline authenticated">
         <%block name="navigation_global_links_authenticated">
-          % if settings.FEATURES.get('COURSES_ARE_BROWSABLE') and not show_program_listing:
-            <li class="item nav-global-01">
-              <a href="${marketing_link('COURSES')}">${_('Browse Labs')}</a>
-            </li>
-          % endif
           % if settings.LABSTER_FEATURES.get('ENABLE_VOUCHERS') and user.is_active:
             <li class="nav-global-01">
               <a href="${reverse('enter_voucher')}">${_('Enter access code')}</a>


### PR DESCRIPTION
**Description:** 
The Browse Labs button is misleading for users who log into their account as it takes them to the simulation catalog which then asks them to subscribe to the monthly subscription to gain access, which is irrelevant since they are most likely already enrolled in a course. This mainly affects faculty who are enrolled in a course by Sales team members for a trial, and have a poor experience when they think that we are trying to have them pay for what was presented as a free trial.
See screencast of user journey here: https://www.useloom.com/share/b38fcf07f00a4db8aee825a936e483ae

**JIRA:** https://liv-it.atlassian.net/browse/WEB-768

**Merge deadline:** List merge deadline (if any)

**Fix:** 
![screenshot from 2017-12-22 17-26-42](https://user-images.githubusercontent.com/25189966/34293840-118d54aa-e741-11e7-8295-7beaff7b2e57.png)

**Configuration instructions:** List any non-trivial configuration
instructions (if any).

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
