### PR TITLE
WEB-2590: Incorrect role when coach has more than one CCX course

### DIFF
--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -45,8 +45,7 @@ from student.roles import (
     GlobalStaff,
     SupportStaffRole,
     OrgInstructorRole,
-    OrgStaffRole,
-    CourseCcxCoachRole,  # Added by labster.
+    OrgStaffRole
 )
 from util.milestones_helpers import (
     get_pre_requisite_courses_not_completed,
@@ -88,12 +87,12 @@ def has_ccx_coach_role(user, course_key):
 
         if role.has_user(user):
             list_ccx = CustomCourseForEdX.objects.filter(
+                pk=ccx_id,
                 course_id=course_key.to_course_locator(),
                 coach=user
             )
-            if list_ccx.exists():
-                coach_ccx = list_ccx[0]
-                return str(coach_ccx.id) == ccx_id
+            return list_ccx.exists()
+
     else:
         raise CCXLocatorValidationException("Invalid CCX key. To verify that "
                                             "user is a coach on CCX, you must provide key to CCX")
@@ -884,11 +883,11 @@ def get_user_role(user, course_key):
         ccx = CustomCourseForEdX.objects.get(pk=course_key.ccx)
         if CourseCcxCoachRole(ccx.course_id).has_user(user):
             list_ccx = CustomCourseForEdX.objects.filter(
+                pk=course_key.ccx,
                 course_id=course_key.to_course_locator(),
                 coach=user
             )
-            if list_ccx.exists():
-                ccx_coach_role = str(list_ccx[0].id) == str(course_key.ccx)
+            ccx_coach_role = list_ccx.exists()
 
     if role:
         return role


### PR DESCRIPTION
**Description:** Fix bug incorrect role when there are two CCX  using the same coach.

**JIRA:** https://liv-it.atlassian.net/browse/WEB-2590

**Merge deadline:** List merge deadline (if any)

**Configuration instructions:** List any non-trivial configuration
instructions (if any).

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
