### PR TITLE
WEB-2594: Disable enroll by username

### DIFF
--- a/themes/courses.labster.com/lms/templates/ccx/coach_dashboard.html
+++ b/themes/courses.labster.com/lms/templates/ccx/coach_dashboard.html
@@ -138,7 +138,8 @@ from openedx.core.djangolib.js_utils import (
             // this is untenable, tied to a translated value.  Fix it.
             value: 'add'
           });
-          form.append(action).submit();
+          form.append(action);
+          form.find('input[type="submit"]').click();
         } else if (target.hasClass('revoke')) {
           // revoking access for a student, get set form values and submit
           // get the email address of the student, since they might not be 'enrolled' yet.
@@ -183,6 +184,21 @@ from openedx.core.djangolib.js_utils import (
     $errorMessage.hide();
     return true;
   }
+
+  function ccxInviteForm(form) {
+    var emailRegex = /^\s*(?:([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4})\b[,|\s]*)+$/i;
+    var errorMessage = $(form).find('.error-message');
+    var studentsEmail = $(form).find('#student-ids').val();
+    if(!studentsEmail.match(emailRegex)){
+      errorMessage.addClass("request-response-error");
+      errorMessage.text("${_('You have entered invalid data. Please check your input data.') | n, js_escaped_string}");
+
+      return false;
+    }
+
+    return true;
+  }
+
 </script>
 
 <%block name="bodyclass">view-in-course</%block>

--- a/themes/courses.labster.com/lms/templates/ccx/enrollment.html
+++ b/themes/courses.labster.com/lms/templates/ccx/enrollment.html
@@ -6,14 +6,15 @@ from openedx.core.djangolib.markup import HTML, Text
 
 <h2 class="hd hd-2">${_("Batch Enrollment")}</h2>
 <div class="batch-enrollment" style="float:left;width:50%">
-  <form method="POST" action="ccx_invite">
+  <form method="POST" action="ccx_invite" onsubmit="return ccxInviteForm(this)">
+  <p class="error-message"></p>
   <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }">
-  <label for="student-ids" class="sr">${_("Email Addresses/Usernames")}</label>
+  <label for="student-ids" class="sr">${_("Email Addresses")}</label>
   <p id="label_student_ids" class="text-helper">
-      ${_("Enter email addresses and/or usernames separated by new lines or commas.")}
+      ${_("Enter email addresses separated by new lines or commas.")}
       ${_("You will not get notification for emails that bounce, so please double-check spelling.")}
   </p>
-  <textarea rows="6" name="student-ids" id="student-ids" aria-describedby="label_student_ids" placeholder="${_("Email Addresses/Usernames")}" spellcheck="false"></textarea>
+  <textarea rows="6" name="student-ids" id="student-ids" aria-describedby="label_student_ids" placeholder="${_("Email Addresses")}" spellcheck="false"></textarea>
 
 
   <div class="enroll-option">
@@ -79,7 +80,6 @@ from openedx.core.djangolib.markup import HTML, Text
         <table>
           <thead>
             <tr>
-              <td class="label">Username</td>
               <td class="label">Email</td>
               <td class="label">Revoke access</td>
               <td class="label">${_("Enrollment Status")}</td>
@@ -88,17 +88,15 @@ from openedx.core.djangolib.markup import HTML, Text
           <tbody>
             %for member in ccx_members:
             <tr>
-              <td>${member.user}</td>
               <td>${member.user.email}</td>
               <td><a class="revoke"><span class="fa fa-times-circle" aria-hidden="true"></span> ${_("Revoke access")}</a></td>
-               <td>${_("Enrolled")}</td>
+              <td>${_("Enrolled")}</td>
             </tr>
             %endfor
             <!-- Start: Added by Labster -->
             <!-- Add enrollment status -->
             %for member in ccx_enrolls:
             <tr>
-              <td></td>
               <td>${member.email}</td>
               <td><a class="revoke"><span class="fa fa-times-circle" aria-hidden="true"></span> ${_("Revoke access")}</a></td>
               <td>${_("Pending")}</td>
@@ -109,8 +107,9 @@ from openedx.core.djangolib.markup import HTML, Text
         </table>
       </div>
       <div class="bottom-bar">
-        <label for="student-id" class="sr">${_("Enter username or email")}</label>
-        <input name="student-id" id="student-id" class="add-field" placeholder="${_("Enter username or email")}" type="text">
+        <label for="student-id" class="sr">${_("Enter email")}</label>
+        <input name="student-id" id="student-id" class="add-field" placeholder="${_("Enter email")}" type="email">
+        <input type="submit" style="display: none">
         <input name="student-action" class="add" value="Add Student" type="button">
         <div class="enroll-option">
             <input type="checkbox" name="auto-enroll" id="auto-enroll" value="Auto-Enroll" checked="yes" aria-describedby="auto-enroll-helper" disabled>


### PR DESCRIPTION
**Description:** Disable possibility to enroll students by username. Please check on https://edx-eucalyptus-sandbox3.labster.com/
- requirements: 
1. As Instructor, when I open CCX Coach tab I cannot enroll students by username
And I don't see any information about this on UI.
2. As Instructor when I put a wrong data, I'd like to be immediately informed about this. No enrollement has to be done until the data is correct.

**JIRA:** https://liv-it.atlassian.net/browse/WEB-2594

**Merge deadline:** List merge deadline (if any)

**Configuration instructions:** List any non-trivial configuration
instructions (if any).

**Testing instructions:**
1. Open your CCX Coach tab. 
2. Try to enroll using valid/invalid email.

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
