### PR TITLE
WEB-2801: Missing fullname at the beginning of email course creation

### DIFF
--- a/themes/courses.labster.com/lms/templates/emails/enroll_email_ccx_coach_enrolledmessage.txt
+++ b/themes/courses.labster.com/lms/templates/emails/enroll_email_ccx_coach_enrolledmessage.txt
@@ -3,7 +3,11 @@ from django.conf import settings
 from django.utils.translation import ugettext as _
 %>
 
-${_("Hi there,")}
+% if full_name:
+${_("Dear {full_name}, ").format(full_name=full_name)}
+% else:
+${_("Hi there, ")}
+% endif
 
 ${_(
     "Our Customer Success team has created the course {course_name} for you. To enter your course, "

--- a/themes/courses.labster.com/lms/templates/emails/enroll_email_ccx_coach_enrolledmessage.txt
+++ b/themes/courses.labster.com/lms/templates/emails/enroll_email_ccx_coach_enrolledmessage.txt
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.utils.translation import ugettext as _
 %>
 
-${_("Dear {full_name}").format(full_name=full_name)}
+${_("Hi there,")}
 
 ${_(
     "Our Customer Success team has created the course {course_name} for you. To enter your course, "


### PR DESCRIPTION
**Description:** 
When customers are not users yet, e.i. when coach does not already exist, the full name field remains empty and the greeting makes no sense.

Solution: 
if name of user is exist > `Dear <fullname>, ` else `Hi there, ` 

**JIRA:** https://liv-it.atlassian.net/browse/WEB-2801

**Merge deadline:** 31 may 2018

**Configuration instructions:** List any non-trivial configuration
instructions (if any).

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
