### PR TITLE
WEB-2986: Fix error rendering template on Edx

### DIFF
--- a/themes/courses.labster.com/lms/templates/registration/activation_invalid.html
+++ b/themes/courses.labster.com/lms/templates/registration/activation_invalid.html
@@ -13,13 +13,14 @@ from openedx.core.djangolib.markup import HTML, Text
     <h1 class="invalid">${_("Activation Invalid")}</h1>
     <hr class="horizontal-divider">
 
-    <p>${Text(_("Something went wrong. Email programs sometimes split URLs "
-                "into two lines, so make sure the URL you're using is " "formatted correctly. If you still have issues, "
-                "please {link_start}contact us{link_end}.")).format(
-                    link_start=HTML('<a href="{0}">'.format(settings.LABSTER_TECH_SUPPORT_LINK)),
-                    link_end=HTML('</a>')
-                )
-        )}</p>
+    <p>
+        ${Text(_("Something went wrong. Email programs sometimes split URLs "
+        "into two lines, so make sure the URL you're using is " "formatted correctly. If you still have issues, "
+        "please {link_start}contact us{link_end}.")).format(
+            link_start=HTML('<a href="{0}">'.format(settings.LABSTER_TECH_SUPPORT_LINK)),
+            link_end=HTML('</a>')
+        )}
+    </p>
 
     <p>${Text(_('Return to the {link_start}home page{link_end}.')).format(
            link_start=HTML('<a href="/">'), link_end=HTML('</a>'))}</p>

--- a/themes/courses.labster.com/lms/templates/static_templates/server-overloaded.html
+++ b/themes/courses.labster.com/lms/templates/static_templates/server-overloaded.html
@@ -9,7 +9,7 @@ from openedx.core.djangolib.markup import HTML, Text
     <section class="outside-app">
       <h1>
         ${Text(_("Currently the {platform_name} servers are overloaded")).format(
-            platform_name=HTML("<em>{}</em>").format(platform_name=Text(settings.PLATFORM_NAME))
+            platform_name=HTML("<em>{platform_name}</em>").format(platform_name=Text(settings.PLATFORM_NAME))
         )}
       </h1>
       <p>


### PR DESCRIPTION
**Description:** There's python closing tag that need to be removed and fix bug from Edx Side for overload-template.

**JIRA:** https://liv-it.atlassian.net/browse/WEB-2986

**Merge deadline:** List merge deadline (if any)

**Configuration instructions:** List any non-trivial configuration
instructions (if any).

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
