### PR TITLE
WEB-1459: Fix course links 404 if the user is not yet logged in

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -261,6 +261,7 @@ def jump_to(_request, course_id, location):
     return redirect(redirect_url)
 
 
+@login_required
 @ensure_csrf_cookie
 @ensure_valid_course_key
 def course_info(request, course_id):


### PR DESCRIPTION
**Description:** 
An enrolled student is getting Page not Found in Labster.com when the user opened the "You have been enrolled in ..." email and click the course link.
It only happens if user is NOT logged in yet.

**JIRA:** https://liv-it.atlassian.net/browse/WEB-1459

**Merge deadline:** List merge deadline (if any)

**Configuration instructions:** List any non-trivial configuration
instructions (if any).

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
