### PR TITLE
WEB-3133: Stopping students to create unnecessary Labster accounts

### DIFF
--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -105,7 +105,7 @@ def login_and_registration_form(request, initial_mode="login"):
 
     # Start: Added by Labster
     # Show an information message text as it would prevent students to create unnecessary Labster accounts.
-    account_creation_warning_msg = _(
+    register_user_info = _(
         "Have you checked your course module on your school's learning management system?<br /><br />"
         "Labster simulations might have been already integrated into your course module. In this case, "
         "you do NOT need to create a Labster account. We highly recommend you to log in to "
@@ -114,15 +114,14 @@ def login_and_registration_form(request, initial_mode="login"):
     )
 
     # Suggest student to create an account to the appropriate region server based on IP address of user.
-    login_ip_address_warning_msg = register_ip_address_warning_msg = None
+    login_user_info = None
     if settings.LABSTER_FEATURES.get('ENABLE_REGION_IPADDR_WARNING'):
         regions = configuration_helpers.get_value('REGIONS', settings.REGIONS)
         current_region = request.session.get('country_code')
-        # current_region = "UK"
         region = regions.get(current_region)
         if region:
             region_code = region['region_code']
-            login_ip_address_warning_msg = _(
+            login_user_info = _(
                 'It appears that you are based in the {region_code}. '
                 'Please sign in <a href="{login_url}">here</a> instead.'
             ).format(
@@ -130,18 +129,13 @@ def login_and_registration_form(request, initial_mode="login"):
                 login_url=region['login_url']
             )
 
-            register_ip_address_warning_msg = _(
+            register_user_info = _(
                 'It appears that you are based in the {region_code}. '
                 'Please create an account <a href="{register_url}">here</a>.'
             ).format(
                 region_code=region_code,
                 register_url=region['register_url'],
             )
-
-            # Remove account creation message because we already have this warning message and the user
-            # should open the link.
-            account_creation_warning_msg = None
-
 
     # End: Added by Labster
 
@@ -161,9 +155,8 @@ def login_and_registration_form(request, initial_mode="login"):
             'login_form_desc': json.loads(form_descriptions['login']),
             'registration_form_desc': json.loads(form_descriptions['registration']),
             'password_reset_form_desc': json.loads(form_descriptions['password_reset']),
-            'login_ip_address_warning_msg': login_ip_address_warning_msg,
-            'register_ip_address_warning_msg': register_ip_address_warning_msg,
-            'account_creation_warning_msg': account_creation_warning_msg
+            'login_user_info': login_user_info,
+            'register_user_info': register_user_info
         },
         'login_redirect_url': redirect_to,  # This gets added to the query string of the "Sign In" button in header
         'responsive': True,

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -104,11 +104,21 @@ def login_and_registration_form(request, initial_mode="login"):
             pass
 
     # Start: Added by Labster
+    # Show an information message text as it would prevent students to create unnecessary Labster accounts.
+    account_creation_warning_msg = _(
+        "Have you checked your course module on your school's learning management system?<br /><br />"
+        "Labster simulations might have been already integrated into your course module. In this case, "
+        "you do NOT need to create a Labster account. We highly recommend you to log in to "
+        "your course module and check if you already have access to the simulations before creating an account.<br /><br />"
+        "If you are not sure, please refer to your instructor."
+    )
+
     # Suggest student to create an account to the appropriate region server based on IP address of user.
     login_ip_address_warning_msg = register_ip_address_warning_msg = None
     if settings.LABSTER_FEATURES.get('ENABLE_REGION_IPADDR_WARNING'):
         regions = configuration_helpers.get_value('REGIONS', settings.REGIONS)
         current_region = request.session.get('country_code')
+        # current_region = "UK"
         region = regions.get(current_region)
         if region:
             region_code = region['region_code']
@@ -127,6 +137,11 @@ def login_and_registration_form(request, initial_mode="login"):
                 region_code=region_code,
                 register_url=region['register_url'],
             )
+
+            # Remove account creation message because we already have this warning message and the user
+            # should open the link.
+            account_creation_warning_msg = None
+
 
     # End: Added by Labster
 
@@ -147,7 +162,8 @@ def login_and_registration_form(request, initial_mode="login"):
             'registration_form_desc': json.loads(form_descriptions['registration']),
             'password_reset_form_desc': json.loads(form_descriptions['password_reset']),
             'login_ip_address_warning_msg': login_ip_address_warning_msg,
-            'register_ip_address_warning_msg': register_ip_address_warning_msg
+            'register_ip_address_warning_msg': register_ip_address_warning_msg,
+            'account_creation_warning_msg': account_creation_warning_msg
         },
         'login_redirect_url': redirect_to,  # This gets added to the query string of the "Sign In" button in header
         'responsive': True,

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -74,7 +74,7 @@
                 // Added by Labster
                 this.loginIpAddressWarningMsg = options.login_ip_address_warning_msg;
                 this.registerIpAddressWarningMsg = options.register_ip_address_warning_msg;
-
+                this.accountCreationWarningMsg = options.account_creation_warning_msg;
                 // The login view listens for 'sync' events from the reset model
                 this.resetModel = new PasswordResetModel({}, {
                     method: 'GET',
@@ -163,7 +163,8 @@
                         model: model,
                         thirdPartyAuth: this.thirdPartyAuth,
                         platformName: this.platformName,
-                        ipAddressWarningMsg: this.registerIpAddressWarningMsg // Added by Labster
+                        ipAddressWarningMsg: this.registerIpAddressWarningMsg, // Added by Labster
+                        accountCreationWarningMsg: this.accountCreationWarningMsg // Added by Labster
                     });
 
                     // Listen for 'auth-complete' event so we can enroll/redirect the user appropriately.

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -70,11 +70,8 @@
                 };
 
                 this.platformName = options.platform_name;
-
-                // Added by Labster
-                this.loginIpAddressWarningMsg = options.login_ip_address_warning_msg;
-                this.registerIpAddressWarningMsg = options.register_ip_address_warning_msg;
-                this.accountCreationWarningMsg = options.account_creation_warning_msg;
+                this.loginUserInfo = options.login_user_info; // Added by Labster
+                this.registerUserInfo = options.register_user_info; // Added by Labster
                 // The login view listens for 'sync' events from the reset model
                 this.resetModel = new PasswordResetModel({}, {
                     method: 'GET',
@@ -125,7 +122,7 @@
                         resetModel: this.resetModel,
                         thirdPartyAuth: this.thirdPartyAuth,
                         platformName: this.platformName,
-                        ipAddressWarningMsg: this.loginIpAddressWarningMsg // Added by Labster
+                        userInfo: this.loginUserInfo // Added by Labster
                     });
 
                     // Listen for 'password-help' event to toggle sub-views
@@ -163,8 +160,7 @@
                         model: model,
                         thirdPartyAuth: this.thirdPartyAuth,
                         platformName: this.platformName,
-                        ipAddressWarningMsg: this.registerIpAddressWarningMsg, // Added by Labster
-                        accountCreationWarningMsg: this.accountCreationWarningMsg // Added by Labster
+                        userInfo: this.registerUserInfo, // Added by Labster
                     });
 
                     // Listen for 'auth-complete' event so we can enroll/redirect the user appropriately.

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -28,7 +28,7 @@
                 this.currentProvider = data.thirdPartyAuth.currentProvider || '';
                 this.errorMessage = data.thirdPartyAuth.errorMessage || '';
                 this.platformName = data.platformName;
-                this.ipAddressWarningMsg = data.ipAddressWarningMsg || ''; // Added by Labster
+                this.userInfo = data.userInfo || ''; // Added by Labster
                 this.resetModel = data.resetModel;
 
                 this.listenTo( this.model, 'sync', this.saveSuccess );
@@ -48,7 +48,7 @@
                         providers: this.providers,
                         hasSecondaryProviders: this.hasSecondaryProviders,
                         platformName: this.platformName,
-                        ipAddressWarningMsg: this.ipAddressWarningMsg, // Added by Labster
+                        userInfo: this.userInfo, // Added by Labster
                     }
                 }));
 

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -30,6 +30,7 @@
                 this.errorMessage = data.thirdPartyAuth.errorMessage || '';
                 this.platformName = data.platformName;
                 this.ipAddressWarningMsg = data.ipAddressWarningMsg || ''; // Added by Labster
+                this.accountCreationWarningMsg = data.accountCreationWarningMsg || ''; // Added by Labster
                 this.autoSubmit = data.thirdPartyAuth.autoSubmitRegForm;
                 this.listenTo( this.model, 'sync', this.saveSuccess );
             },
@@ -49,6 +50,7 @@
                         hasSecondaryProviders: this.hasSecondaryProviders,
                         platformName: this.platformName,
                         ipAddressWarningMsg: this.ipAddressWarningMsg, // Added by Labster
+                        accountCreationWarningMsg: this.accountCreationWarningMsg, // Added by Labster
                     }
                 }));
 

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -29,8 +29,7 @@
                 this.currentProvider = data.thirdPartyAuth.currentProvider || '';
                 this.errorMessage = data.thirdPartyAuth.errorMessage || '';
                 this.platformName = data.platformName;
-                this.ipAddressWarningMsg = data.ipAddressWarningMsg || ''; // Added by Labster
-                this.accountCreationWarningMsg = data.accountCreationWarningMsg || ''; // Added by Labster
+                this.userInfo = data.userInfo || ''; // Added by Labster
                 this.autoSubmit = data.thirdPartyAuth.autoSubmitRegForm;
                 this.listenTo( this.model, 'sync', this.saveSuccess );
             },
@@ -49,8 +48,7 @@
                         providers: this.providers,
                         hasSecondaryProviders: this.hasSecondaryProviders,
                         platformName: this.platformName,
-                        ipAddressWarningMsg: this.ipAddressWarningMsg, // Added by Labster
-                        accountCreationWarningMsg: this.accountCreationWarningMsg, // Added by Labster
+                        userInfo: this.userInfo, // Added by Labster
                     }
                 }));
 

--- a/lms/templates/student_account/login.underscore
+++ b/lms/templates/student_account/login.underscore
@@ -16,9 +16,9 @@
         </div>
     </div>
 
-    <% if (context.ipAddressWarningMsg) { %>
+    <% if (context.userInfo) { %>
         <div class="status submission-warning" aria-live="polite">
-            <p class="message-copy"><%= context.ipAddressWarningMsg %></p>
+            <p class="message-copy"><%= context.userInfo %></p>
         </div>
     <% } %>
 

--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -2,6 +2,10 @@
     <div class="status submission-warning" aria-live="polite">
         <p class="message-copy"><%= context.ipAddressWarningMsg %></p>
     </div>
+<% } else if (context.accountCreationWarningMsg) { %>
+    <div class="status submission-warning" aria-live="polite">
+        <p class="message-copy"><%= context.accountCreationWarningMsg %></p>
+    </div>
 <% } %>
 
 <div class="status submission-error hidden" aria-live="polite">

--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -1,10 +1,6 @@
-<% if (context.ipAddressWarningMsg) { %>
+<% if (context.userInfo) { %>
     <div class="status submission-warning" aria-live="polite">
-        <p class="message-copy"><%= context.ipAddressWarningMsg %></p>
-    </div>
-<% } else if (context.accountCreationWarningMsg) { %>
-    <div class="status submission-warning" aria-live="polite">
-        <p class="message-copy"><%= context.accountCreationWarningMsg %></p>
+        <p class="message-copy"><%= context.userInfo %></p>
     </div>
 <% } %>
 


### PR DESCRIPTION
**Description:** 
Problem: CS has recently started receiving a lot of questions about enrollment from universities that are supposed to access the simulations on their own learning management systems.

Solution:
Adding the text below on the account creation page:

> Have you checked your course module on your school's learning management system?
>
> Labster simulations might have been already integrated into your course module. In this case, you do NOT need to create a Labster account. We highly recommend you to log in to your course module and check if you already have access to the simulations before creating an account.
>
> If you are not sure, please refer to your instructor.

![screenshot from 2018-10-11 13-35-44](https://user-images.githubusercontent.com/25189966/46785744-50747300-cd65-11e8-8e4b-ae923895f393.png)

**JIRA:** https://liv-it.atlassian.net/browse/WEB-3133

**Sandboxes:** https://edx-eucalyptus.labster.com/

**Merge deadline:** List merge deadline (if any)

**Configuration instructions:** List any non-trivial configuration
instructions (if any).

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
