### PR TITLE
WEB-3255: Extend student list management on ccx_coach tab with the fu…

### DIFF
--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -161,7 +161,7 @@ def dashboard(request, course, ccx=None):
         # Hide internal users from coaches view.
         is_staff = has_access(request.user, 'staff', course)
         is_instructor = has_access(request.user, 'instructor', course)
-        ccx_members = CourseEnrollment.objects.filter(course_id=ccx_locator, is_active=True)
+        ccx_members = CourseEnrollment.objects.filter(course_id=ccx_locator, is_active=True).select_related('user__profile')
         ccx_enrolls = CourseEnrollmentAllowed.may_enroll_and_unenrolled(ccx_locator)
         if not all([is_staff, is_instructor]):
             ccx_members = ccx_members.exclude(user__courseaccessrole__role__in=('instructor', 'staff',))

--- a/themes/courses.labster.com/lms/templates/ccx/enrollment.html
+++ b/themes/courses.labster.com/lms/templates/ccx/enrollment.html
@@ -86,7 +86,7 @@ from openedx.core.djangolib.markup import HTML, Text
           </colgroup>
           <thead>
             <tr>
-              <td class="label">Name</td>
+              <td class="label">Full Name</td>
               <td class="label">Email</td>
               <td class="label">Revoke access</td>
               <td class="label">${_("Enrollment Status")}</td>
@@ -95,7 +95,7 @@ from openedx.core.djangolib.markup import HTML, Text
           <tbody>
             %for member in ccx_members:
             <tr>
-              <td>${member.user.profile.name}</td>
+              <td>${member.user.profile.name if member.user.profile else ''}</td>
               <td>${member.user.email}</td>
               <td><a class="revoke"><span class="fa fa-times-circle" aria-hidden="true"></span> ${_("Revoke access")}</a></td>
               <td>${_("Enrolled")}</td>

--- a/themes/courses.labster.com/lms/templates/ccx/enrollment.html
+++ b/themes/courses.labster.com/lms/templates/ccx/enrollment.html
@@ -5,7 +5,7 @@ from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <h2 class="hd hd-2">${_("Batch Enrollment")}</h2>
-<div class="batch-enrollment" style="float:left;width:50%">
+<div class="batch-enrollment" style="float:left;width:45%">
   <form method="POST" action="ccx_invite" onsubmit="return ccxInviteForm(this)">
   <p class="error-message"></p>
   <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }">
@@ -62,7 +62,7 @@ from openedx.core.djangolib.markup import HTML, Text
   </form>
 </div>
 
-<div class="member-lists-management" style="float:left;width:50%">
+<div class="member-lists-management" style="float:left;width:55%">
   <form method="POST" action="ccx_manage_student" class="ccx-manage-student-form">
   <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }">
   <div class="auth-list-container active">
@@ -78,8 +78,15 @@ from openedx.core.djangolib.markup import HTML, Text
           </div>
         %endif
         <table>
+          <colgroup>
+            <col width="50">
+            <col width="70">
+            <col width="50">
+            <col width="35">
+          </colgroup>
           <thead>
             <tr>
+              <td class="label">Name</td>
               <td class="label">Email</td>
               <td class="label">Revoke access</td>
               <td class="label">${_("Enrollment Status")}</td>
@@ -88,6 +95,7 @@ from openedx.core.djangolib.markup import HTML, Text
           <tbody>
             %for member in ccx_members:
             <tr>
+              <td>${member.user.profile.name}</td>
               <td>${member.user.email}</td>
               <td><a class="revoke"><span class="fa fa-times-circle" aria-hidden="true"></span> ${_("Revoke access")}</a></td>
               <td>${_("Enrolled")}</td>
@@ -97,6 +105,7 @@ from openedx.core.djangolib.markup import HTML, Text
             <!-- Add enrollment status -->
             %for member in ccx_enrolls:
             <tr>
+              <td></td>
               <td>${member.email}</td>
               <td><a class="revoke"><span class="fa fa-times-circle" aria-hidden="true"></span> ${_("Revoke access")}</a></td>
               <td>${_("Pending")}</td>


### PR DESCRIPTION
**Description:** Extend student list management on ccx_coach tab with the full name column.

**JIRA:** https://liv-it.atlassian.net/browse/WEB-3255

![screenshot from 2018-11-01 14-33-45](https://user-images.githubusercontent.com/25189966/47836801-9660ac00-dde4-11e8-8de2-1f6b8f05f1ed.png)

**Merge deadline:** List merge deadline (if any)

**Configuration instructions:** List any non-trivial configuration
instructions (if any).

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
