### PR TITLE
TESLA-148: Update error message in course code view

### DIFF
--- a/lms/djangoapps/labster_vouchers/views.py
+++ b/lms/djangoapps/labster_vouchers/views.py
@@ -178,7 +178,13 @@ def activate_voucher_view(request):
         messages.error(request, _(u"No course found for enrollment."))
         return redirect(enter_voucher_url)
     except CourseEnrollmentExistsError:
-        messages.error(request, _(u"You have been already enrolled to the course before."))
+        messages.error(
+            request,
+            _(
+                u"You have successfully activated the course code and enrolled yourself in the course. "
+                u"Please continue to the dashboard to see your course and access the simulations."
+            )
+        )
         return redirect(enter_voucher_url)
     except CourseEnrollmentError:
         messages.error(

--- a/lms/djangoapps/labster_vouchers/views.py
+++ b/lms/djangoapps/labster_vouchers/views.py
@@ -181,7 +181,7 @@ def activate_voucher_view(request):
         messages.error(
             request,
             _(
-                u"You have successfully activated the course code and enrolled yourself in the course. "
+                u"You have successfully activated the access code and enrolled yourself in the course. "
                 u"Please continue to the dashboard to see your course and access the simulations."
             )
         )


### PR DESCRIPTION
**Description:** Update error message in course code view
Edx message: 
`You have been already enrolled to the course before.`
To
`You have successfully activated the access code and enrolled yourself in the course. Please continue to the dashboard to see your course and access the simulations`

API message: 
`Course code is set for license. Can not continue without course code applying. `
To
`You cannot continue without applying a course code. Please apply your course code. `

**JIRA:** https://liv-it.atlassian.net/browse/TESLA-148

**Other PR:**
https://github.com/Livit/Livit.Learn.LTI/pull/1165

**Merge deadline:** List merge deadline (if any)

**Configuration instructions:** List any non-trivial configuration
instructions (if any).

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
